### PR TITLE
fix: add z to fix button overlaying menu

### DIFF
--- a/src/features/donations/components/PaypalButton/PaypalButton.tsx
+++ b/src/features/donations/components/PaypalButton/PaypalButton.tsx
@@ -18,7 +18,7 @@ export const PaypalButton = () => {
             color: "silver",
             label: "paypal",
           }}
-          className="flex h-[56px] bg-[#EEEEEE] hover:bg-[#E2E2E2] rounded-md justify-start items-center"
+          className="flex z-10 h-[56px] bg-[#EEEEEE] hover:bg-[#E2E2E2] rounded-md justify-start items-center"
           createOrder={createOrder(donationValue)}
           onApprove={captureOrder} />
       }


### PR DESCRIPTION
Adiciona um z-10 no botão do paypal que antes aparecia por cima do menu no mobile